### PR TITLE
兼容picGo的base64和path

### DIFF
--- a/src/uploader.ts
+++ b/src/uploader.ts
@@ -5,8 +5,16 @@ import picgo from 'picgo'
 
 export default class Uploader {
   async handle(ctx: picgo) {
+    let transformer = ctx.getConfig('picBed.transformer')
     for (let i in ctx.input) {
-      let img = await this.upload(ctx, ctx.input[i])
+      let img: any
+      if (transformer == 'base64'){
+        //use buffer
+        img = await this.upload(ctx, null, ctx.input[i].buffer)
+      }else{
+        //use filePath
+        img = await this.upload(ctx, ctx.input[i], null)
+      }
       ctx.log.info(`output url = ${img.url}`)
       ctx.output[i].imgUrl = img.url
       ctx.output[i].base64Image = img.imgStr
@@ -14,10 +22,14 @@ export default class Uploader {
     }
   }
 
-  upload = async (ctx: picgo, filePath: string) => {
-    let f = readFileSync(filePath)
-
-    let imgStr = base64.fromByteArray(f)
+  upload = async (ctx: picgo, filePath: string, buffer: Buffer) => {
+    let imgStr: string
+    if (buffer !== null){
+      imgStr = buffer.toString('base64')
+    }else{
+      let f = readFileSync(filePath)
+      imgStr = base64.fromByteArray(f)
+    }
     const config = ctx.getConfig('picBed.azure')
 
     let org = config.username


### PR DESCRIPTION
谢谢！这个插件解决了我图床转移到azure的需求，不过在使用期间遇到了一个bug。

picGo的transformer有base64和path两种，而[uploader.js](https://github.com/CaiJingLong/picgo-plugin-azure/blob/master/src/uploader.ts#L18)好像把path默认作为了transformer给出的input形式。
某些其他插件（比如说[picgo-plugin-pic-migrater](https://github.com/PicGo/picgo-plugin-pic-migrater)）会把base64设定为transformer的input格式（https://github.com/PicGo/picgo-plugin-pic-migrater/blob/dev/src/lib/Migrater.ts#L26）。
如果我想用这个azure插件配合pic migrater把图床转移到dev azure git上，那么uploader就可能会接收到一个buffer对象而不是一段path地址，此时就会产生type error。